### PR TITLE
fix: usage of deprecated method

### DIFF
--- a/src/wviacam.cpp
+++ b/src/wviacam.cpp
@@ -451,7 +451,7 @@ void WViacam::OnMenuOptionsClick( wxCommandEvent& event )
 void WViacam::OnIconize( wxIconizeEvent& event )
 {
 #if defined(WIN32)
-	if (event.Iconized()) {
+	if (event.IsIconized()) {
 		// Cancel current iconization and hide window.
 		Iconize (false);
 		Show(false);


### PR DESCRIPTION
Usage of deprecated method causes Windows build to fail with a compiler error.