### PR TITLE
fix: change LENGHT to LENGTH

### DIFF
--- a/creavision/crvcamera_v4l2.cpp
+++ b/creavision/crvcamera_v4l2.cpp
@@ -223,11 +223,11 @@ void CCameraV4L2::DoClose ()
 
 bool CCameraV4L2::InternalOpen()
 {
-	char devName[CAM_DEVICE_SHORT_NAME_LENGHT+5];
+	char devName[CAM_DEVICE_SHORT_NAME_LENGTH+5];
 	struct stat st;	
 
 	// Create device name
-	snprintf (devName, CAM_DEVICE_SHORT_NAME_LENGHT+5, "/dev/%s", g_deviceShortNames[m_Id]);
+	snprintf (devName, CAM_DEVICE_SHORT_NAME_LENGTH+5, "/dev/%s", g_deviceShortNames[m_Id]);
 
 	// Check if exists and if it is a device
 	if (stat (devName, &st)== -1) {
@@ -1659,9 +1659,9 @@ void CCameraControlV4L2::Dump()
 // Static attributes
 //
 int CCameraV4L2::g_numDevices= -1;
-char CCameraV4L2::g_deviceNames[MAX_CAM_DEVICES][CAM_DEVICE_NAME_LENGHT];
-char CCameraV4L2::g_deviceShortNames[MAX_CAM_DEVICES][CAM_DEVICE_SHORT_NAME_LENGHT];
-char CCameraV4L2::g_deviceDriverNames[MAX_CAM_DEVICES][CAM_DEVICE_DRIVER_NAME_LENGHT];
+char CCameraV4L2::g_deviceNames[MAX_CAM_DEVICES][CAM_DEVICE_NAME_LENGTH];
+char CCameraV4L2::g_deviceShortNames[MAX_CAM_DEVICES][CAM_DEVICE_SHORT_NAME_LENGTH];
+char CCameraV4L2::g_deviceDriverNames[MAX_CAM_DEVICES][CAM_DEVICE_DRIVER_NAME_LENGTH];
 int CCameraV4L2::g_numInstances= 0;
 
 void CCameraV4L2::InstanceCreated()
@@ -1718,9 +1718,9 @@ int CCameraV4L2::GetNumDevices()
 				
 				// Prepend device number and append device name
 				unsigned int j= count - 1 - i;
-				snprintf (g_deviceNames[j], CAM_DEVICE_NAME_LENGHT, " (Id:%d) %s", j, device->name);		
-				snprintf (g_deviceShortNames[j], CAM_DEVICE_SHORT_NAME_LENGHT, "%s", device->shortName);
-				snprintf (g_deviceDriverNames[j], CAM_DEVICE_DRIVER_NAME_LENGHT, "%s", device->driver);
+				snprintf (g_deviceNames[j], CAM_DEVICE_NAME_LENGTH, " (Id:%d) %s", j, device->name);
+				snprintf (g_deviceShortNames[j], CAM_DEVICE_SHORT_NAME_LENGTH, "%s", device->shortName);
+				snprintf (g_deviceDriverNames[j], CAM_DEVICE_DRIVER_NAME_LENGTH, "%s", device->driver);
 
 				if (slog_get_priority ()>= SLOG_PRIO_DEBUG) {
 					CHandle handle = c_open_device(device->shortName);

--- a/creavision/crvcamera_v4l2.h
+++ b/creavision/crvcamera_v4l2.h
@@ -79,12 +79,12 @@ private:
 	//
 	// Static members
 	//
-	enum { MAX_CAM_DEVICES= 10, CAM_DEVICE_NAME_LENGHT= 50 };
+	enum { MAX_CAM_DEVICES= 10, CAM_DEVICE_NAME_LENGTH= 50 };
 	static int g_numDevices;
-	static char g_deviceNames[MAX_CAM_DEVICES][CAM_DEVICE_NAME_LENGHT];
-	enum { CAM_DEVICE_SHORT_NAME_LENGHT= 32, CAM_DEVICE_DRIVER_NAME_LENGHT= 20 };
-	static char g_deviceShortNames[MAX_CAM_DEVICES][CAM_DEVICE_SHORT_NAME_LENGHT];
-	static char g_deviceDriverNames[MAX_CAM_DEVICES][CAM_DEVICE_DRIVER_NAME_LENGHT];
+	static char g_deviceNames[MAX_CAM_DEVICES][CAM_DEVICE_NAME_LENGTH];
+	enum { CAM_DEVICE_SHORT_NAME_LENGTH= 32, CAM_DEVICE_DRIVER_NAME_LENGTH= 20 };
+	static char g_deviceShortNames[MAX_CAM_DEVICES][CAM_DEVICE_SHORT_NAME_LENGTH];
+	static char g_deviceDriverNames[MAX_CAM_DEVICES][CAM_DEVICE_DRIVER_NAME_LENGTH];
 	// Instance count for automatic libwebcam cleanup
 	static int g_numInstances;
 	// Instances inc/dec

--- a/creavision/crvcamera_wdm.cpp
+++ b/creavision/crvcamera_wdm.cpp
@@ -125,7 +125,7 @@ void CCameraWDM::ShowSettingsDialog ()
 }
 
 int CCameraWDM::g_numDevices= -1;
-char CCameraWDM::g_deviceNames[MAX_CAM_DEVICES][CAM_DEVICE_NAME_LENGHT];
+char CCameraWDM::g_deviceNames[MAX_CAM_DEVICES][CAM_DEVICE_NAME_LENGTH];
 
 int CCameraWDM::GetNumDevices() 
 { 
@@ -136,7 +136,7 @@ int CCameraWDM::GetNumDevices()
 		if (g_numDevices> MAX_CAM_DEVICES) g_numDevices= MAX_CAM_DEVICES;		
 		for (int i= 0; i< g_numDevices; ++i) {
 			// Prepend device number and append device name
-			_snprintf (g_deviceNames[i], CAM_DEVICE_NAME_LENGHT, " (Id:%d) %s\0", i, videoInput::getDeviceName(i));
+			_snprintf (g_deviceNames[i], CAM_DEVICE_NAME_LENGTH, " (Id:%d) %s\0", i, videoInput::getDeviceName(i));
 		}		
 	}
 


### PR DESCRIPTION
Commit 56318af1 did change the spelling only in `crvcamera_wdm.h`, but not in the implementation file. That broke the build on win32. This commit fixes that and substitutes every other occurrence to make them consistent.