### PR TITLE
feat: option to disable dwell click on start

### DIFF
--- a/src/clickwindowcontroller.cpp
+++ b/src/clickwindowcontroller.cpp
@@ -148,6 +148,7 @@ void CClickWindowController::Show(bool show)
 void CClickWindowController::Reset() 
 {
 	m_enabled= true;
+	m_enabledOnStart= true;
 	m_currentButton= LEFT;
 	m_lockedButton= LEFT;
 	m_halfDragClick= false;
@@ -402,6 +403,11 @@ void CClickWindowController::SetFastMode(bool enable)
 	m_fastMode= enable;
 }
 
+void CClickWindowController::SetEnabledOnStart(bool enable)
+{
+	m_enabledOnStart= enable;
+}
+
 void CClickWindowController::SetAutohide(bool enable) 
 {
 	// TODO
@@ -439,6 +445,7 @@ void CClickWindowController::SetWarnBarOverlap (bool value)
 // Configuration methods
 void CClickWindowController::InitDefaults()
 {
+	m_enabledOnStart = true;
 	SetFastMode (false);
 	SetDesign (CClickWindowController::NORMAL);	
 	//SetDockingMode(CClickWindowController::TOP_DOCKING);
@@ -451,6 +458,7 @@ void CClickWindowController::WriteProfileData(wxConfigBase* pConfObj)
 {
 	pConfObj->SetPath (_T("clickWindow"));	
 
+	pConfObj->Write(_T("enabledOnStart"), m_enabledOnStart);
 	pConfObj->Write(_T("fastMode"), m_fastMode);
 	pConfObj->Write(_T("design"), (long) m_design);
 	pConfObj->Write(_T("location"), (long) m_location);
@@ -466,6 +474,8 @@ void CClickWindowController::ReadProfileData(wxConfigBase* pConfObj)
 	long design, location;
 	bool warnBarOverlap= true;
 	
+	pConfObj->Read(_T("enabledOnStart"), &m_enabledOnStart);
+		m_enabled = m_enabledOnStart;
 	pConfObj->Read(_T("fastMode"), &m_fastMode);
 	if (pConfObj->Read(_T("design"), &design))
 		SetDesign ((CClickWindowController::EDesign) design);

--- a/src/clickwindowcontroller.h
+++ b/src/clickwindowcontroller.h
@@ -69,6 +69,9 @@ public:
 	inline const EButton GetLockedButton () const;
 
 	bool GetEnabled () const { return  m_enabled; }
+
+	bool GetEnabledOnStart() const { return m_enabledOnStart; }
+	void SetEnabledOnStart(bool enable);
 	
 	bool GetAutohide() const { return m_autohide; }
 	void SetAutohide(bool enable);
@@ -102,6 +105,7 @@ private:
 	CViacamController * m_pViacamController;
 	
 	bool m_enabled;
+	bool m_enabledOnStart;
 	EButton m_currentButton;
 	EButton m_lockedButton;
 	bool m_halfDragClick;

--- a/src/viacamcontroller.cpp
+++ b/src/viacamcontroller.cpp
@@ -64,6 +64,7 @@ CViacamController::CViacamController(void)
 , m_cameraName()
 , m_enabled(false)
 , m_enabledAtStartup(false)
+, m_enabledClickAtStartup(false)
 , m_languageId(wxLANGUAGE_DEFAULT)
 , m_onScreenKeyboardCommand()
 , m_frameRate(0)
@@ -83,6 +84,7 @@ void CViacamController::InitDefaults()
 	m_runWizardAtStartup= true;
 	m_languageId= wxLANGUAGE_DEFAULT;
 	m_enabledAtStartup= false;
+	m_enabledClickAtStartup = false;
 	m_minimisedAtStartup = false;
 #if defined(__WXMSW__)
 	m_onScreenKeyboardCommand= _T("osk.exe");
@@ -414,6 +416,7 @@ void CViacamController::WriteAppData(wxConfigBase* pConfObj)
 void CViacamController::WriteProfileData(wxConfigBase* pConfObj)
 {
 	pConfObj->Write(_T("enabledAtStartup"), m_enabledAtStartup);
+	pConfObj->Write(_T("enabledClickAtStartup"), m_enabledClickAtStartup);
 	pConfObj->Write(_T("onScreenKeyboardCommand"), m_onScreenKeyboardCommand);
 	pConfObj->Write(_T("runWizardAtStartup"), m_runWizardAtStartup);
 	pConfObj->Write(_T("minimisedAtStartup"), m_minimisedAtStartup);
@@ -435,6 +438,7 @@ void CViacamController::ReadAppData(wxConfigBase* pConfObj)
 void CViacamController::ReadProfileData(wxConfigBase* pConfObj)
 {
 	pConfObj->Read(_T("enabledAtStartup"), &m_enabledAtStartup);
+	pConfObj->Read(_T("enabledClickAtStartup"), &m_enabledClickAtStartup);
 	pConfObj->Read(_T("onScreenKeyboardCommand"), &m_onScreenKeyboardCommand);
 	pConfObj->Read(_T("runWizardAtStartup"), &m_runWizardAtStartup);
 	pConfObj->Read(_T("minimisedAtStartup"), &m_minimisedAtStartup);

--- a/src/viacamcontroller.h
+++ b/src/viacamcontroller.h
@@ -59,6 +59,9 @@ public:
 	const bool GetEnabledAtStartup () const { return m_enabledAtStartup; }
 	void SetEnabledAtStartup (bool value) { m_enabledAtStartup= value; }
 
+	const bool GetEnabledClickAtStartup () const { return m_enabledClickAtStartup; }
+	void SetEnabledClickAtStartup (bool value) { m_enabledClickAtStartup = value; }
+
 	const bool GetMinimisedAtStartup () const { return m_minimisedAtStartup; }
 	void SetMinimisedAtStartup (bool value) { m_minimisedAtStartup = value; }
 
@@ -185,6 +188,7 @@ private:
 	wxString m_cameraName;
 	volatile bool m_enabled;
 	bool m_enabledAtStartup;
+	bool m_enabledClickAtStartup;
 	int m_languageId;
 	wxString m_onScreenKeyboardCommand;
 	float m_frameRate;

--- a/src/wconfiguration.cpp
+++ b/src/wconfiguration.cpp
@@ -81,6 +81,7 @@ BEGIN_EVENT_TABLE( WConfiguration, wxDialog )
     EVT_SPINCTRL( ID_SPINCTRL_BOTTOM_WORKSPACE, WConfiguration::OnSpinctrlBottomWorkspaceUpdated )
     EVT_CHECKBOX( ID_CHECKBOX2, WConfiguration::OnCheckboxWrapPointer )
     EVT_CHECKBOX( ID_CHECKBOX_ENABLE_DWELL, WConfiguration::OnCheckboxEnableDwellClick )
+    EVT_CHECKBOX( ID_CHECKBOX_ENABLE_DWELL_ON_START, WConfiguration::OnCheckboxEnableDwellClickOnStart )
     EVT_SPINCTRL( ID_SPINCTRL_DWELL_TIME, WConfiguration::OnSpinctrlDwellTimeUpdated )
     EVT_SPINCTRL( ID_SPINCTRL_DWELL_AREA, WConfiguration::OnSpinctrlDwellAreaUpdated )
     EVT_CHECKBOX( ID_CHECKBOX_ALLOW_CONSECUTIVE, WConfiguration::OnCheckboxAllowConsecutiveClick )
@@ -225,6 +226,7 @@ void WConfiguration::Init()
     m_chkWrapPointer = NULL;
     m_panelClick = NULL;
     m_chkDwellClickEnabled = NULL;
+    m_chkDwellClickEnabledOnStart = NULL;
     m_stDwellTime = NULL;
     m_spinDwellTime = NULL;
     m_stDwellArea = NULL;
@@ -494,6 +496,12 @@ void WConfiguration::CreateControls()
     if (WConfiguration::ShowToolTips())
         m_chkDwellClickEnabled->SetToolTip(_("Enable/Disable automatic (dwell)\nclick generation mechanism."));
     itemStaticBoxSizer47->Add(m_chkDwellClickEnabled, 0, wxALIGN_LEFT|wxALL, 5);
+
+    m_chkDwellClickEnabledOnStart = new wxCheckBox(itemStaticBoxSizer47->GetStaticBox(), ID_CHECKBOX_ENABLE_DWELL_ON_START, _("Enable click on start"));
+    m_chkDwellClickEnabledOnStart->SetValue(true);
+    if (WConfiguration::ShowToolTips())
+        m_chkDwellClickEnabled->SetToolTip(_("Click is enabled when application starts."));
+    itemStaticBoxSizer47->Add(m_chkDwellClickEnabledOnStart, 0, wxALIGN_LEFT | wxALL, 5);
 
     wxGridSizer* itemGridSizer49 = new wxGridSizer(0, 2, 0, 0);
     itemStaticBoxSizer47->Add(itemGridSizer49, 0, wxGROW, 5);
@@ -990,6 +998,8 @@ void WConfiguration::InitializeData ()
 	// Clic
 	m_chkDwellClickEnabled->SetValue (
 		wxGetApp().GetController().GetPointerAction().GetClickMode()!= CPointerAction::NONE);
+    m_chkDwellClickEnabledOnStart->SetValue(
+        wxGetApp().GetController().GetPointerAction().GetDwellClick().GetClickWindowController().GetEnabledOnStart());
 #if defined(__WXGTK__)
 	m_chkEnableGestureClick->SetValue (
 		wxGetApp().GetController().GetPointerAction().GetClickMode()== CPointerAction::GESTURE);
@@ -1113,6 +1123,7 @@ void WConfiguration::UpdateGUIClickOptions()
 
 void WConfiguration::EnableGUIGeneralClickOptions (bool enable)
 {
+    m_chkDwellClickEnabledOnStart->Enable(enable);
 	m_spinDwellTime->Enable(enable);
 	m_spinDwellArea->Enable(enable);
 	m_chkAllowConsecutiveClick->Enable(enable);
@@ -1307,6 +1318,19 @@ void WConfiguration::OnCheckboxEnableDwellClick( wxCommandEvent& event )
 	}		
 	m_chkDwellClickEnabled->SetValue (wxGetApp().GetController().GetPointerAction().GetClickMode()!= CPointerAction::NONE);
 	event.Skip(false);	
+}
+
+
+/*!
+ * wxEVT_COMMAND_CHECKBOX_CLICKED event handler for ID_CHECKBOX_ENABLE_DWELL_ON_START
+ */
+
+void WConfiguration::OnCheckboxEnableDwellClickOnStart(wxCommandEvent& event)
+{
+    wxGetApp().GetController().GetPointerAction().GetDwellClick().
+        GetClickWindowController().SetEnabledOnStart(m_chkDwellClickEnabledOnStart->GetValue());
+    event.Skip(false);
+    Changed();
 }
 
 #if defined(__WXGTK__)

--- a/src/wconfiguration.h
+++ b/src/wconfiguration.h
@@ -80,6 +80,7 @@ class wxPanel;
 #define ID_CHECKBOX2 10067
 #define ID_PANEL_CLICK 10024
 #define ID_CHECKBOX_ENABLE_DWELL 10031
+#define ID_CHECKBOX_ENABLE_DWELL_ON_START 10040
 #define ID_STATIC_DWELL_TIME 10072
 #define ID_SPINCTRL_DWELL_TIME 10005
 #define ID_STATIC_DWELL_AREA 10073
@@ -205,6 +206,9 @@ private:
 
     /// wxEVT_COMMAND_CHECKBOX_CLICKED event handler for ID_CHECKBOX_ENABLE_DWELL
     void OnCheckboxEnableDwellClick( wxCommandEvent& event );
+
+    /// wxEVT_COMMAND_CHECKBOX_CLICKED event handler for ID_CHECKBOX_ENABLE_DWELL_ON_START
+    void OnCheckboxEnableDwellClickOnStart( wxCommandEvent& event );
 
     /// wxEVT_COMMAND_SPINCTRL_UPDATED event handler for ID_SPINCTRL_DWELL_TIME
     void OnSpinctrlDwellTimeUpdated( wxSpinEvent& event );
@@ -380,6 +384,7 @@ private:
     wxCheckBox* m_chkWrapPointer;
     wxPanel* m_panelClick;
     wxCheckBox* m_chkDwellClickEnabled;
+    wxCheckBox* m_chkDwellClickEnabledOnStart;
     wxStaticText* m_stDwellTime;
     wxSpinCtrl* m_spinDwellTime;
     wxStaticText* m_stDwellArea;


### PR DESCRIPTION
Rationale: assume we have eViacam configured to use dwell click and to start tracking on open. We have autostart (or someone else) open the app before we are in front of the PC. Afterward, while we take place in front of the PC, any movement in front of the camera may cause clicks at random places with unwanted effects. With this option we can enable dwell click from the click toolbar when we are ready.